### PR TITLE
fix: use committed node modules

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           node-version: 16.x
           cache: npm
-      - name: Install dependencies
-        run: npm install
       - name: Rebuild the dist/ directory
         run: npm run build
       - name: Compare the expected and actual dist/ directories


### PR DESCRIPTION
This PR removes `npm install` process in the check-dist job since the folder should be committed. 