### PR TITLE
fix: publish release and to GitHub Actions Marketplace

### DIFF
--- a/.github/workflows/e2e-test-setup.yml
+++ b/.github/workflows/e2e-test-setup.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # E2E test cases on Notation: Setup
+      # E2E test cases on Notation Setup
       - name: Setup Notation
         uses: ./setup
     

--- a/.github/workflows/e2e-test-sign.yml
+++ b/.github/workflows/e2e-test-sign.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           notation cert generate-test "e2e-test"
 
-      # E2E test cases on Notation: Sign
+      # E2E test cases on Notation Sign
       - name: Sign artifact using notation plugin
         uses: ./sign
         with:

--- a/.github/workflows/e2e-test-verify.yml
+++ b/.github/workflows/e2e-test-verify.yml
@@ -68,7 +68,7 @@ jobs:
           plugin_config: |-
             keyFile=${{ env.E2E_KEY }}
     
-      # E2E test cases on Notation: Verify
+      # E2E test cases on Notation Verify
       - name: Verify released artifact
         uses: ./verify
         with:

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -11,18 +11,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Update major and minor versions
+name: Update major and minor tags
 
 on:
   release:
     types: [published]
 
 jobs:
-  tag:
+  update-major-minor-tags:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Git config

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -1,39 +1,25 @@
-# Trigger the workflow after publishing releases
 name: Update major and minor versions
 run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
 
 on:
-  workflow_dispatch:
-    inputs:
-      target:
-        description: The tag or reference to use
-        required: true
-      major_version:
-        type: choice
-        description: The major version to update
-        required: true
-        options:
-          - v1
-      minor_version:
-        description: The minor version to update
-        required: true
+  release:
+    types: [published]
 
 jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Git config
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-    - name: Tag new target
-      run: | 
-        git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
-        git tag -f ${{ github.event.inputs.minor_version }} ${{ github.event.inputs.target }}
-    - name: Push new tag
-      run: | 
-        git push origin ${{ github.event.inputs.major_version }} --force
-        git push origin ${{ github.event.inputs.minor_version }} --force
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Tag new target
+        run: | 
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}  
+          git tag -f ${MAJOR} ${VERSION}
+          git push origin ${MAJOR} --force

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -1,0 +1,39 @@
+# Trigger the workflow after publishing releases
+name: Update major and minor versions
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        required: true
+        options:
+          - v1
+      minor_version:
+        description: The minor version to update
+        required: true
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Git config
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - name: Tag new target
+      run: | 
+        git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+        git tag -f ${{ github.event.inputs.minor_version }} ${{ github.event.inputs.target }}
+    - name: Push new tag
+      run: | 
+        git push origin ${{ github.event.inputs.major_version }} --force
+        git push origin ${{ github.event.inputs.minor_version }} --force

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -29,11 +29,15 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - name: Tag new target
+      - name: Tag and push new major and minor versions
         run: | 
-          VERSION=${GITHUB_REF#refs/tags/}
-          MAJOR=${VERSION%%.*}
+          VERSION=${{ github.event.release.tag_name }}
+          export MAJOR=$(echo ${VERSION} | cut -d '.' -f 1)
+          export MINOR=${MAJOR}.$(echo ${VERSION} | cut -d '.' -f 2)
           echo ${VERSION}
           echo ${MAJOR}
+          echo ${MINOR}
           git tag -f ${MAJOR} ${VERSION}
+          git tag -f ${MINOR} ${VERSION}
           git push origin ${MAJOR} --force
+          git push origin ${MINOR} --force

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -32,11 +32,29 @@ jobs:
       - name: Tag and push new major and minor versions
         run: | 
           VERSION=${{ github.event.release.tag_name }}
-          export MAJOR=$(echo ${VERSION} | cut -d '.' -f 1)
-          export MINOR=${MAJOR}.$(echo ${VERSION} | cut -d '.' -f 2)
-          echo ${VERSION}
-          echo ${MAJOR}
-          echo ${MINOR}
+          MAJOR=$(echo ${VERSION} | cut -d '.' -f 1)
+          MINOR=${MAJOR}.$(echo ${VERSION} | cut -d '.' -f 2)
+          if [ -z ${VERSION} ]
+          then
+            echo "released tag cannot be empty"
+            exit 1
+          else
+            echo "released tag is ${VERSION}"
+          fi
+          if [ -z ${MAJOR} ]
+          then
+            echo "major tag cannot be empty"
+            exit 1
+          else
+            echo "major tag is ${MAJOR}"
+          fi
+          if [ -z ${MINOR} ]
+          then
+            echo "minor tag cannot be empty"
+            exit 1
+          else
+            echo "minor tag is ${MINOR}"
+          fi
           git tag -f ${MAJOR} ${VERSION}
           git tag -f ${MINOR} ${VERSION}
           git push origin ${MAJOR} --force

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -1,3 +1,16 @@
+# Copyright The Notary Project Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Update major and minor versions
 run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
 

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 name: Update major and minor versions
-run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
 
 on:
   release:
@@ -33,6 +32,8 @@ jobs:
       - name: Tag new target
         run: | 
           VERSION=${GITHUB_REF#refs/tags/}
-          MAJOR=${VERSION%%.*}  
+          MAJOR=${VERSION%%.*}
+          echo ${VERSION}
+          echo ${MAJOR}
           git tag -f ${MAJOR} ${VERSION}
           git push origin ${MAJOR} --force

--- a/.github/workflows/update-major-and-minor-version.yml
+++ b/.github/workflows/update-major-and-minor-version.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Git config

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following three actions are available:
 
 ## Usage
 
-### Notation: Setup
+### Notation Setup
 ```yaml
 - name: setup Notation CLI
   uses: notaryproject/notation-action/setup@main
@@ -29,7 +29,7 @@ For example,
     version: "1.0.0"
 ```
 
-### Notation: Sign
+### Notation Sign
 ```yaml
 - name: sign releasd artifact with signing plugin
   uses: notaryproject/notation-action/sign@main
@@ -77,7 +77,7 @@ Example of using the [Referrers API](https://github.com/opencontainers/distribut
       self_signed=false
 ```
 
-### Notation: Verify
+### Notation Verify
 ```yaml
 - name: verify released artifact
   uses: notaryproject/notation-action/verify@main

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+# Copyright The Notary Project Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Notation: Setup'
+description: Setup Notation CLI on GitHub Action runners
+branding:
+  icon: check-circle
+  color: blue
+inputs:
+  version:
+    description: version of official Notation CLI [release](https://github.com/notaryproject/notation/releases). This field is ignored if 'url' is present.
+    required: false
+    default: "1.0.0"
+  url:
+    description: url of customized Notation CLI to install
+    required: false
+  checksum:
+    description: SHA256 of the customized Notation CLI. Required if 'url' is present.
+    required: false
+runs:
+  using: node16
+  main: ./dist/setup.js

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@
 name: 'Notation: Setup'
 description: Setup Notation CLI on GitHub Action runners
 branding:
-  icon: check-circle
+  icon: shield
   color: blue
 inputs:
   version:

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Notation: Setup'
-description: Setup Notation CLI on GitHub Action runners
+name: 'Notation Setup'
+description: Set up Notation CLI on GitHub Action runners for signing and verifying OCI artifacts
 branding:
   icon: shield
   color: blue

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -14,7 +14,7 @@
 name: 'Notation: Setup'
 description: Setup Notation CLI on GitHub Action runners
 branding:
-  icon: check-circle
+  icon: shield
   color: blue
 inputs:
   version:

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Notation: Setup'
-description: Setup Notation CLI on GitHub Action runners
+name: 'Notation Setup'
+description: Set up Notation CLI on GitHub Action runners for signing and verifying OCI artifacts
 branding:
   icon: shield
   color: blue

--- a/sign/action.yml
+++ b/sign/action.yml
@@ -11,10 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Notation: Sign'
+name: 'Notation Sign'
 description: notation sign target artifact with plugin
 branding:
-  icon: check-circle
+  icon: shield
   color: blue
 inputs:
   plugin_name:

--- a/verify/action.yml
+++ b/verify/action.yml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Notation: Verify'
+name: 'Notation Verify'
 description: notation verify target artifact
 branding:
   icon: shield

--- a/verify/action.yml
+++ b/verify/action.yml
@@ -14,7 +14,7 @@
 name: 'Notation: Verify'
 description: notation verify target artifact
 branding:
-  icon: check-circle
+  icon: shield
   color: blue
 inputs:
   target_artifact_reference:


### PR DESCRIPTION
This PR enables notation-action to be published to GitHub Actions Marketplace.

This PR also adds in a new workflow to force tag the major and minor versions after a certain release.
(tested with: https://github.com/Two-Hearts/notation-action/actions/runs/6230190133/job/16909839109)