### PR TITLE
bump: Upgrade to use Notation v1.1.1

### DIFF
--- a/.github/workflows/e2e-test-setup.yml
+++ b/.github/workflows/e2e-test-setup.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Setup Notation using URL
         uses: ./setup
         with:
-            url: https://github.com/notaryproject/notation/releases/download/v1.1.0/notation_1.1.0_linux_amd64.tar.gz
-            checksum: 0e31e156edff6cc324405cda391d7144b0b99c265a7bdfa6644f457e530fe6d4
+            url: https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_amd64.tar.gz
+            checksum: de5f9845505b38fd30c2b1f4c2172ae517e3eba3e9836647f14525daa0f930c1
 
       - name: Setup Notation using URL without checksum
         id: no-checksum
         continue-on-error: true
         uses: ./setup
         with:
-          url: https://github.com/notaryproject/notation/releases/download/v1.1.0/notation_1.1.0_linux_amd64.tar.gz
+          url: https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_amd64.tar.gz
       - name: 'Should Fail: Setup Notation using URL without checksum'
         if: steps.no-checksum.outcome != 'failure'
         run: |
@@ -63,7 +63,7 @@ jobs:
         continue-on-error: true
         uses: ./setup
         with:
-          url: https://github.com/notaryproject/notation/releases/download/v1.1.0/notation_1.1.0_linux_amd64.tar.gz
+          url: https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_amd64.tar.gz
           checksum: abcedf
       - name: 'Should Fail: Setup Notation using URL and invalid checksum'
         if: steps.invalid-checksum.outcome != 'failure'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Currently, [Azure Key Vault plugin for Notation](https://github.com/Azure/notati
 - name: setup Notation CLI
   uses: notaryproject/notation-action/setup@v1
   with:
-    version: "1.1.0"
+    version: "1.1.1"
 ```
 
 </details>

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   version:
     description: version of official Notation CLI [release](https://github.com/notaryproject/notation/releases). This field is ignored if 'url' is present.
     required: false
-    default: "1.1.0"
+    default: "1.1.1"
   url:
     description: url of customized Notation CLI to install
     required: false

--- a/dist/lib/data/notation_releases.json
+++ b/dist/lib/data/notation_releases.json
@@ -1,4 +1,32 @@
 {
+    "1.1.1": {
+        "darwin": {
+            "amd64": {
+                "checksum": "b336e7a13612b1aa52b5a682247a2742f0683f7adb7811a5ae35e75d04bf8e87",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_darwin_amd64.tar.gz"
+            },
+            "arm64": {
+                "checksum": "e7a68e56736a9b435707326c61331e4402b90bb83154bee4ce6bf619efade28f",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_darwin_arm64.tar.gz"
+            }
+        },
+        "linux": {
+            "amd64": {
+                "checksum": "de5f9845505b38fd30c2b1f4c2172ae517e3eba3e9836647f14525daa0f930c1",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_amd64.tar.gz"
+            },
+            "arm64": {
+                "checksum": "f035db321a112887dac1c2e7e9d0f60afa2e332174ab956ea6a901fc5488a218",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_arm64.tar.gz"
+            }
+        },
+        "windows": {
+            "amd64": {
+                "checksum": "bf4e928f43409b8b2ce640dc284f847b6de4e02c53f60b3171298bc28b296258",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_windows_amd64.zip"
+            }
+        }
+    },
     "1.1.0": {
         "darwin": {
             "amd64": {

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -20,7 +20,7 @@ inputs:
   version:
     description: version of official Notation CLI [release](https://github.com/notaryproject/notation/releases). This field is ignored if 'url' is present.
     required: false
-    default: "1.1.0"
+    default: "1.1.1"
   url:
     description: url of customized Notation CLI to install
     required: false

--- a/src/lib/data/notation_releases.json
+++ b/src/lib/data/notation_releases.json
@@ -1,4 +1,32 @@
 {
+    "1.1.1": {
+        "darwin": {
+            "amd64": {
+                "checksum": "b336e7a13612b1aa52b5a682247a2742f0683f7adb7811a5ae35e75d04bf8e87",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_darwin_amd64.tar.gz"
+            },
+            "arm64": {
+                "checksum": "e7a68e56736a9b435707326c61331e4402b90bb83154bee4ce6bf619efade28f",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_darwin_arm64.tar.gz"
+            }
+        },
+        "linux": {
+            "amd64": {
+                "checksum": "de5f9845505b38fd30c2b1f4c2172ae517e3eba3e9836647f14525daa0f930c1",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_amd64.tar.gz"
+            },
+            "arm64": {
+                "checksum": "f035db321a112887dac1c2e7e9d0f60afa2e332174ab956ea6a901fc5488a218",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_linux_arm64.tar.gz"
+            }
+        },
+        "windows": {
+            "amd64": {
+                "checksum": "bf4e928f43409b8b2ce640dc284f847b6de4e02c53f60b3171298bc28b296258",
+                "url": "https://github.com/notaryproject/notation/releases/download/v1.1.1/notation_1.1.1_windows_amd64.zip"
+            }
+        }
+    },
     "1.1.0": {
         "darwin": {
             "amd64": {


### PR DESCRIPTION
This PR upgrades notation-action to use Notation v1.1.1 as default.